### PR TITLE
Enhanced DTO layer and updated configs

### DIFF
--- a/src/MLS.Api/appsettings.Development.json
+++ b/src/MLS.Api/appsettings.Development.json
@@ -6,6 +6,6 @@
     }
   },
   "ConnectionStrings": {
-    "MatLidConnectionString": "Data Source=.;Initial Catalog=MatLabDB;Integrated Security=True;Trust Server Certificate=True"
+    "MatLidConnectionString": "Data Source=.;Initial Catalog=MatLidStoreDB;Integrated Security=True;Trust Server Certificate=True"
   }
 }

--- a/src/MLS.Domain/MLS.Domain.csproj
+++ b/src/MLS.Domain/MLS.Domain.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/src/MSL.Application/DTO/Address/AddressDetailsDto.cs
+++ b/src/MSL.Application/DTO/Address/AddressDetailsDto.cs
@@ -2,5 +2,14 @@
 {
     public class AddressDetailsDto
     {
+        public int Id { get; set; }
+        public string Street { get; set; }
+        public string City { get; set; }
+        public string State { get; set; }
+        public string Country { get; set; }
+        public string PostalCode { get; set; }
+        public int UserId { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
     }
 }

--- a/src/MSL.Application/DTO/Article/ArticleDetailsDto.cs
+++ b/src/MSL.Application/DTO/Article/ArticleDetailsDto.cs
@@ -1,6 +1,19 @@
-﻿namespace MLS.Application.DTO.Article
+﻿using MLS.Application.DTO.Comment;
+using MLS.Application.DTO.User;
+
+namespace MLS.Application.DTO.Article
 {
     public class ArticleDetailsDto
     {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public string Content { get; set; }
+        public string Author { get; set; }
+        public DateTime PublicationDate { get; set; }
+        public int AuthorId { get; set; }
+        public UserDto AuthorUser { get; set; }
+        public List<CommentDetailsDto> Comments { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
     }
 }

--- a/src/MSL.Application/DTO/Category/CategoryDetailsDto.cs
+++ b/src/MSL.Application/DTO/Category/CategoryDetailsDto.cs
@@ -1,6 +1,14 @@
-﻿namespace MLS.Application.DTO.Category
+﻿using MLS.Application.DTO.Product;
+
+namespace MLS.Application.DTO.Category
 {
     public class CategoryDetailsDto
     {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public List<ProductDetailsDto> Products { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
     }
 }

--- a/src/MSL.Application/MappingProfiles/AddressProfile.cs
+++ b/src/MSL.Application/MappingProfiles/AddressProfile.cs
@@ -9,6 +9,9 @@ namespace MLS.Application.MappingProfiles
         public AddressProfile()
         {
             CreateMap<AddressDto, Address>().ReverseMap();
+            CreateMap<Address, AddressDetailsDto>();
+            CreateMap<Address, CreateAddressDto>();
+            CreateMap<Address, UpdateAddressDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/ArticleProfile.cs
+++ b/src/MSL.Application/MappingProfiles/ArticleProfile.cs
@@ -1,4 +1,6 @@
 ﻿using AutoMapper;
+using MLS.Application.DTO.Article;
+using MLS.Domain.Entities;
 
 namespace MLS.Application.MappingProfiles
 {
@@ -6,6 +8,10 @@ namespace MLS.Application.MappingProfiles
     {
         public ArticleProfile()
         {
+            CreateMap<ArticleDto, Article>().ReverseMap();
+            CreateMap<Article, ArticleDetailsDto>();
+            CreateMap<Article, CreateArticleDto>();
+            CreateMap<Article, UpdateArticleDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/CategoryProfile.cs
+++ b/src/MSL.Application/MappingProfiles/CategoryProfile.cs
@@ -1,4 +1,6 @@
 ﻿using AutoMapper;
+using MLS.Application.DTO.Category;
+using MLS.Domain.Entities;
 
 namespace MLS.Application.MappingProfiles
 {
@@ -6,6 +8,10 @@ namespace MLS.Application.MappingProfiles
     {
         public CategoryProfile()
         {
+            CreateMap<CategoryDto, Category>().ReverseMap();
+            CreateMap<Category, CategoryDetailsDto>();
+            CreateMap<Category, CreateCategoryDto>();
+            CreateMap<Category, UpdateCategoryDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/CommentProfile.cs
+++ b/src/MSL.Application/MappingProfiles/CommentProfile.cs
@@ -1,4 +1,6 @@
 ﻿using AutoMapper;
+using MLS.Application.DTO.Comment;
+using MLS.Domain.Entities;
 
 namespace MLS.Application.MappingProfiles
 {
@@ -6,6 +8,10 @@ namespace MLS.Application.MappingProfiles
     {
         public CommentProfile()
         {
+            CreateMap<CommentDto, Comment>().ReverseMap();
+            CreateMap<Comment, CommentDetailsDto>();
+            CreateMap<Comment, CreateCommentDto>();
+            CreateMap<Comment, UpdateCommentDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/DiscountProfile.cs
+++ b/src/MSL.Application/MappingProfiles/DiscountProfile.cs
@@ -1,4 +1,6 @@
 ﻿using AutoMapper;
+using MLS.Application.DTO.Discount;
+using MLS.Domain.Entities;
 
 namespace MLS.Application.MappingProfiles
 {
@@ -6,6 +8,10 @@ namespace MLS.Application.MappingProfiles
     {
         public DiscountProfile()
         {
+            CreateMap<DiscountDto, Discount>().ReverseMap();
+            CreateMap<Discount, DiscountDetailsDto>();
+            CreateMap<Discount, CreateDiscountDto>();
+            CreateMap<Discount, UpdateDiscountDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/NotificationProfile.cs
+++ b/src/MSL.Application/MappingProfiles/NotificationProfile.cs
@@ -1,4 +1,6 @@
 ﻿using AutoMapper;
+using MLS.Application.DTO.Notification;
+using MLS.Domain.Entities;
 
 namespace MLS.Application.MappingProfiles
 {
@@ -6,6 +8,10 @@ namespace MLS.Application.MappingProfiles
     {
         public NotificationProfile()
         {
+            CreateMap<NotificationDto, Notification>().ReverseMap();
+            CreateMap<Notification, NotificationDetailsDto>();
+            CreateMap<Notification, CreateNotificationDto>();
+            CreateMap<Notification, UpdateNotificationDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/OrderDetailProfile.cs
+++ b/src/MSL.Application/MappingProfiles/OrderDetailProfile.cs
@@ -1,4 +1,6 @@
 ﻿using AutoMapper;
+using MLS.Application.DTO.OrderDetail;
+using MLS.Domain.Entities;
 
 namespace MLS.Application.MappingProfiles
 {
@@ -6,6 +8,10 @@ namespace MLS.Application.MappingProfiles
     {
         public OrderDetailProfile()
         {
+            CreateMap<OrderDetailDto, OrderDetail>().ReverseMap();
+            CreateMap<OrderDetail, OrderDetailDetailsDto>();
+            CreateMap<OrderDetail, CreateOrderDetailDto>();
+            CreateMap<OrderDetail, UpdateOrderDetailDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/OrderProfile.cs
+++ b/src/MSL.Application/MappingProfiles/OrderProfile.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using MLS.Application.DTO.Order;
+using MLS.Application.DTO.OrderDetail;
 using MLS.Domain.Entities;
 
 namespace MLS.Application.MappingProfiles
@@ -10,6 +11,8 @@ namespace MLS.Application.MappingProfiles
         {
             CreateMap<OrderDto, Order>().ReverseMap();
             CreateMap<Order, OrderDetailsDto>();
+            CreateMap<Order, CreateOrderDetailDto>();
+            CreateMap<Order, UpdateOrderDetailDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/PaymentProfile.cs
+++ b/src/MSL.Application/MappingProfiles/PaymentProfile.cs
@@ -1,4 +1,6 @@
 ﻿using AutoMapper;
+using MLS.Application.DTO.Payment;
+using MLS.Domain.Entities;
 
 namespace MLS.Application.MappingProfiles
 {
@@ -6,6 +8,10 @@ namespace MLS.Application.MappingProfiles
     {
         public PaymentProfile()
         {
+            CreateMap<PaymentDto, Payment>().ReverseMap();
+            CreateMap<Payment, PaymentDetailsDto>();
+            CreateMap<Payment, CreatePaymentDto>();
+            CreateMap<Payment, UpdatePaymentDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/ProductColorProfile.cs
+++ b/src/MSL.Application/MappingProfiles/ProductColorProfile.cs
@@ -1,4 +1,6 @@
 ﻿using AutoMapper;
+using MLS.Application.DTO.ProductColor;
+using MLS.Domain.Entities;
 
 namespace MLS.Application.MappingProfiles
 {
@@ -6,6 +8,10 @@ namespace MLS.Application.MappingProfiles
     {
         public ProductColorProfile()
         {
+            CreateMap<ProductColorDto, ProductColor>().ReverseMap();
+            CreateMap<ProductColor, ProductColorDetailsDto>();
+            CreateMap<ProductColor, CreateProductColorDto>();
+            CreateMap<ProductColor, UpdateProductColorDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/ProductImageProfile.cs
+++ b/src/MSL.Application/MappingProfiles/ProductImageProfile.cs
@@ -1,4 +1,6 @@
 ﻿using AutoMapper;
+using MLS.Application.DTO.ProductImage;
+using MLS.Domain.Entities;
 
 namespace MLS.Application.MappingProfiles
 {
@@ -6,6 +8,10 @@ namespace MLS.Application.MappingProfiles
     {
         public ProductImageProfile()
         {
+            CreateMap<ProductImageDto, ProductImage>().ReverseMap();
+            CreateMap<ProductImage, ProductImageDetailsDto>();
+            CreateMap<ProductImage, CreateProductImageDto>();
+            CreateMap<ProductImage, UpdateProductImageDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/ProductOptionProfile.cs
+++ b/src/MSL.Application/MappingProfiles/ProductOptionProfile.cs
@@ -1,4 +1,6 @@
 ﻿using AutoMapper;
+using MLS.Application.DTO.ProductOption;
+using MLS.Domain.Entities;
 
 namespace MLS.Application.MappingProfiles
 {
@@ -6,6 +8,10 @@ namespace MLS.Application.MappingProfiles
     {
         public ProductOptionProfile()
         {
+            CreateMap<ProductOptionDto, ProductOption>().ReverseMap();
+            CreateMap<ProductOption, ProductOptionDetailsDto>();
+            CreateMap<ProductOption, CreateProductOptionDto>();
+            CreateMap<ProductOption, UpdateProductOptionDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/ProductProfile.cs
+++ b/src/MSL.Application/MappingProfiles/ProductProfile.cs
@@ -10,6 +10,8 @@ namespace MLS.Application.MappingProfiles
         {
             CreateMap<ProductDto, Product>().ReverseMap();
             CreateMap<Product, ProductDetailsDto>();
+            CreateMap<Product, CreateProductDto>();
+            CreateMap<Product, UpdateProductDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/ProductReviewProfile.cs
+++ b/src/MSL.Application/MappingProfiles/ProductReviewProfile.cs
@@ -1,4 +1,6 @@
 ﻿using AutoMapper;
+using MLS.Application.DTO.ProductReview;
+using MLS.Domain.Entities;
 
 namespace MLS.Application.MappingProfiles
 {
@@ -6,6 +8,10 @@ namespace MLS.Application.MappingProfiles
     {
         public ProductReviewProfile()
         {
+            CreateMap<ProductReviewDto, ProductReview>();
+            CreateMap<ProductReview, ProductReviewDetailsDto>();
+            CreateMap<ProductReview, CreateProductReviewDto>();
+            CreateMap<ProductReview, UpdateProductReviewDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/ProductTagProfile.cs
+++ b/src/MSL.Application/MappingProfiles/ProductTagProfile.cs
@@ -1,4 +1,6 @@
 ﻿using AutoMapper;
+using MLS.Application.DTO.ProductTag;
+using MLS.Domain.Entities;
 
 namespace MLS.Application.MappingProfiles
 {
@@ -6,6 +8,10 @@ namespace MLS.Application.MappingProfiles
     {
         public ProductTagProfile()
         {
+            CreateMap<ProductTagDto, ProductTag>().ReverseMap();
+            CreateMap<ProductTag, ProductTagDetailsDto>();
+            CreateMap<ProductTag, CreateProductTagDto>();
+            CreateMap<ProductTag, UpdateProductTagDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/ShipmentProfile.cs
+++ b/src/MSL.Application/MappingProfiles/ShipmentProfile.cs
@@ -1,4 +1,6 @@
 ﻿using AutoMapper;
+using MLS.Application.DTO.Shipment;
+using MLS.Domain.Entities;
 
 namespace MLS.Application.MappingProfiles
 {
@@ -6,6 +8,10 @@ namespace MLS.Application.MappingProfiles
     {
         public ShipmentProfile()
         {
+            CreateMap<ShipmentDto, Shipment>().ReverseMap();
+            CreateMap<Shipment, ShipmentDetailsDto>();
+            CreateMap<Shipment, CreateShipmentDto>();
+            CreateMap<Shipment, UpdateShipmentDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/ShoppingCartItemProfile.cs
+++ b/src/MSL.Application/MappingProfiles/ShoppingCartItemProfile.cs
@@ -1,4 +1,6 @@
 ﻿using AutoMapper;
+using MLS.Application.DTO.ShoppingCartItem;
+using MLS.Domain.Entities;
 
 namespace MLS.Application.MappingProfiles
 {
@@ -6,6 +8,10 @@ namespace MLS.Application.MappingProfiles
     {
         public ShoppingCartItemProfile()
         {
+            CreateMap<ShoppingCartItemDto, ShoppingCartItem>().ReverseMap();
+            CreateMap<ShoppingCartItem, ShoppingCartItemDetailsDto>();
+            CreateMap<ShoppingCartItem, CreateShoppingCartItemDto>();
+            CreateMap<ShoppingCartItem, UpdateShoppingCartItemDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/ShoppingCartProfile.cs
+++ b/src/MSL.Application/MappingProfiles/ShoppingCartProfile.cs
@@ -1,4 +1,6 @@
 ﻿using AutoMapper;
+using MLS.Application.DTO.ShoppingCart;
+using MLS.Domain.Entities;
 
 namespace MLS.Application.MappingProfiles
 {
@@ -6,6 +8,10 @@ namespace MLS.Application.MappingProfiles
     {
         public ShoppingCartProfile()
         {
+            CreateMap<ShoppingCartDto, ShoppingCart>().ReverseMap();
+            CreateMap<ShoppingCart, ShoppingCartDetailsDto>();
+            CreateMap<ShoppingCart, CreateShoppingCartDto>();
+            CreateMap<ShoppingCart, UpdateShoppingCartDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/SupplierProfile.cs
+++ b/src/MSL.Application/MappingProfiles/SupplierProfile.cs
@@ -1,4 +1,6 @@
 ﻿using AutoMapper;
+using MLS.Application.DTO.Supplier;
+using MLS.Domain.Entities;
 
 namespace MLS.Application.MappingProfiles
 {
@@ -6,6 +8,10 @@ namespace MLS.Application.MappingProfiles
     {
         public SupplierProfile()
         {
+            CreateMap<SupplierDto, Supplier>().ReverseMap();
+            CreateMap<Supplier, SupplierDetailsDto>();
+            CreateMap<Supplier, CreateSupplierDto>();
+            CreateMap<Supplier, UpdateSupplierDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/SupplyProfile.cs
+++ b/src/MSL.Application/MappingProfiles/SupplyProfile.cs
@@ -1,4 +1,6 @@
 ﻿using AutoMapper;
+using MLS.Application.DTO.Supply;
+using MLS.Domain.Entities;
 
 namespace MLS.Application.MappingProfiles
 {
@@ -6,6 +8,10 @@ namespace MLS.Application.MappingProfiles
     {
         public SupplyProfileL()
         {
+            CreateMap<SupplyDto, Supply>().ReverseMap();
+            CreateMap<Supply, SupplyDetailsDto>();
+            CreateMap<Supply, CreateSupplyDto>();
+            CreateMap<Supply, UpdateSupplyDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/TagProfile.cs
+++ b/src/MSL.Application/MappingProfiles/TagProfile.cs
@@ -1,4 +1,6 @@
 ﻿using AutoMapper;
+using MLS.Application.DTO.Tag;
+using MLS.Domain.Entities;
 
 namespace MLS.Application.MappingProfiles
 {
@@ -6,6 +8,10 @@ namespace MLS.Application.MappingProfiles
     {
         public TagProfile()
         {
+            CreateMap<TagDto, Tag>().ReverseMap();
+            CreateMap<Tag, TagDetailsDto>();
+            CreateMap<Tag, CreateTagDto>();
+            CreateMap<Tag, UpdateTagDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/UserProfile.cs
+++ b/src/MSL.Application/MappingProfiles/UserProfile.cs
@@ -1,4 +1,6 @@
 ﻿using AutoMapper;
+using MLS.Application.DTO.User;
+using MLS.Domain.Entities;
 
 namespace MLS.Application.MappingProfiles
 {
@@ -6,6 +8,10 @@ namespace MLS.Application.MappingProfiles
     {
         public UserProfile()
         {
+            CreateMap<UserDto, User>().ReverseMap();
+            CreateMap<User, UserDetailsDto>();
+            CreateMap<User, CreateUserDto>();
+            CreateMap<User, UpdateUserDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/WishlistItemProfile.cs
+++ b/src/MSL.Application/MappingProfiles/WishlistItemProfile.cs
@@ -1,11 +1,17 @@
 ﻿using AutoMapper;
+using MLS.Application.DTO.WishListItem;
+using MLS.Domain.Entities;
 
 namespace MLS.Application.MappingProfiles
 {
-    public class WishlistItemProfile : Profile
+    public class WishListItemProfile : Profile
     {
-        public WishlistItemProfile()
+        public WishListItemProfile()
         {
+            CreateMap<WishListItemDto, WishListItem>().ReverseMap();
+            CreateMap<WishListItem, WishListItemDetailsDto>();
+            CreateMap<WishListItem, CreateWishListItemDto>();
+            CreateMap<WishListItem, UpdateWishListItemDto>();
         }
     }
 }

--- a/src/MSL.Application/MappingProfiles/WishlistProfile.cs
+++ b/src/MSL.Application/MappingProfiles/WishlistProfile.cs
@@ -1,11 +1,17 @@
 ﻿using AutoMapper;
+using MLS.Application.DTO.WishList;
+using MLS.Domain.Entities;
 
 namespace MLS.Application.MappingProfiles
 {
-    public class WishlistProfile : Profile
+    public class WishListProfile : Profile
     {
-        public WishlistProfile()
+        public WishListProfile()
         {
+            CreateMap<WishListDto, WishList>().ReverseMap();
+            CreateMap<WishList, WishListDetailsDto>();
+            CreateMap<WishList, CreateWishListDto>();
+            CreateMap<WishList, UpdateWishListDto>();
         }
     }
 }


### PR DESCRIPTION
- Updated `MatLidConnectionString` in `appsettings.Development.json` to use `MatLidStoreDB`.
- Added a BOM to `MLS.Domain.csproj` and changed `<Nullable>` setting from `enable` to `disable`.
- Introduced new DTO classes for entities like `AddressDetailsDto`, `ArticleDetailsDto`, etc., covering a wide range of properties.
- Expanded AutoMapper profiles with mappings for new DTOs and entities, ensuring seamless data conversion.
- Renamed `WishlistItemProfile` to `WishListItemProfile` and `WishlistProfile` to `WishListProfile` for naming consistency.