### PR TITLE
Update .gitignore to exclude ssl/ directory and testem.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,4 +361,3 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
-/src/MLS.MatLidStoreUI/src/app/core/ssl

--- a/src/MLS.MatLidStoreUI/.gitignore
+++ b/src/MLS.MatLidStoreUI/.gitignore
@@ -40,3 +40,6 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+# Application
+ssl/


### PR DESCRIPTION
The .gitignore file was modified to ignore the ssl/ directory
under the MigrationBackup/ section and the testem.log file.
This helps in keeping the repository clean by excluding these
files and directories from version control.