### PR TITLE
Update CI workflow and Husky installation process

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,7 +1,4 @@
-﻿# This workflow will build a .NET project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
-
-name: Full Solution CI
+﻿name: Full Solution CI
 
 on:
   push:
@@ -44,11 +41,9 @@ jobs:
 
     - name: Install dependencies
       run: npm install
+      env:
+        HUSKY: 0  # Bỏ qua cài đặt husky trong CI
       working-directory: ./src/MLS.MatLidStoreUI
-
-    - name: Install Husky
-      run: npx husky install
-      working-directory: ../
 
     - name: Build Angular application
       run: npm run build

--- a/src/MLS.MatLidStoreUI/package.json
+++ b/src/MLS.MatLidStoreUI/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write \"src/**/*.{ts,html}\"",
     "lint": "eslint \"src/**/*.{ts,html}\"",
     "lint:fix": "prettier --write \"src/**/*.{ts,html}\" --ignore-unknown && eslint \"src/**/*.{ts,html}\" --fix",
-    "prepare": "husky install"
+    "prepare": "if [ -d .git ]; then husky install; fi"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
- Updated `dotnet.yml` to improve CI for .NET project
- Retained workflow triggers on `push` and `pull_request`
- Set `node-version` to `18.17.0`
- Added `HUSKY=0` to skip Husky installation in CI
- Removed explicit `npx husky install` step
- Modified `prepare` script to conditionally install Husky